### PR TITLE
fixed stats of newly caught pokemon in the gui

### DIFF
--- a/src/main/kotlin/ink/abb/pogo/scraper/gui/SocketServer.kt
+++ b/src/main/kotlin/ink/abb/pogo/scraper/gui/SocketServer.kt
@@ -123,6 +123,7 @@ class SocketServer {
         newPokemon.name = pokemon.pokemonId.name
         newPokemon.cp = pokemon.cp
         newPokemon.iv = pokemon.getIvPercentage()
+        newPokemon.stats = pokemon.getStatsFormatted()
         server?.broadcastOperations?.sendEvent("newPokemon", newPokemon)
     }
 
@@ -207,6 +208,7 @@ class SocketServer {
         var name: String? = null
         var cp: Int? = null
         var iv: Int? = null
+        var stats: String? = null
     }
 
     class EventReleasePokemon {


### PR DESCRIPTION
**Fixed issue:**
stats (IV and stamina/attack/def) have not been displayed for newly caught pokemon in the rocket theme ui

**Changes made:**
stats var in EventNewPokemon
